### PR TITLE
Set up a default ZSH prompt 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 */src/**
 */*.tar.zst
 */*.tar.zst.sig
+*/*.src.tar.gz.sig
 */*.tar.gz

--- a/arquivolta-base/PKGBUILD
+++ b/arquivolta-base/PKGBUILD
@@ -7,6 +7,14 @@ arch=('any')
 url="https://github.com/arquivolta/repo"
 license=('GPL2')
 depends=(
-  'git' 'zsh' 'sudo' 'docker' 'htop' 'tmux' 'go' 'vim' 'zenity'
+  'git' 'zsh' 'sudo' 'go'
   'wsl-enable-systemd' 'wsl-set-up-wsld' 'wsl-use-windows-openssh'
+  'arquivolta-new-user-template'
+)
+optdepends=(
+  'docker: docker'
+  'tmux: tmux'
+  'htop: htop'
+  'zenity: zenity'
+  'vim: vim'
 )

--- a/arquivolta-new-user-template/PKGBUILD
+++ b/arquivolta-new-user-template/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Anaïs Betts <support@arquivolta.dev>
+pkgname=arquivolta-new-user-template
+pkgver=0.0.1
+pkgrel=1
+pkgdesc="Set up new user templates for Arquivolta"
+arch=('any')
+url="https://github.com/arquivolta/new-user-template"
+license=('GPL2')
+depends=(zsh zsh-syntax-highlighting zsh-completions fzf ripgrep arquivolta-zsh-pure-prompt)
+makedepends=(make)
+checkdepends=()
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+source=("https://github.com/arquivolta/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
+noextract=()
+sha256sums=('569dd934e05b95ff23d92c15c53396ce9e20800efbf8bfabcfe6229abfd260e2')
+
+package() {
+	cd "$pkgname-$pkgver"
+	make DESTDIR="$pkgdir/" install
+}

--- a/arquivolta-zsh-pure-prompt/PKGBUILD
+++ b/arquivolta-zsh-pure-prompt/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Ani Betts <support@arquivolta.dev>
+# Original Code By: Matthew McGinn <mamcgi@gmail.com>
+# Contributor: Jeff Henson <jeff@henson.io>
+# Contributor: Daniel Greve <greve.daniel.l@gmail.com>
+
+pkgname=arquivolta-zsh-pure-prompt
+pkgver=1.20.0
+pkgrel=1
+pkgdesc='Pretty, minimal and fast ZSH prompt'
+arch=('any')
+url='https://github.com/sindresorhus/pure'
+_github_url='https://github.com/sindresorhus/pure'
+license=('MIT')
+depends=('git' 'zsh')
+source=("https://github.com/sindresorhus/pure/archive/v${pkgver}.tar.gz")
+sha256sums=('1fa82dc9c6894dab65d845f38a2c24c790b0095d175da22902a0eee9ea0dd38a')
+
+package() {
+  cd "${srcdir}/pure-${pkgver}"
+  install -Dm644 pure.zsh "${pkgdir}/usr/share/zsh/functions/Prompts/prompt_pure_setup"
+  install -Dm644 async.zsh "${pkgdir}/usr/share/zsh/functions/Prompts/async"
+  install -Dm644 license "${pkgdir}/usr/share/licenses/zsh-pure-prompt/license"
+}


### PR DESCRIPTION
This sets up a Batteries-Included ZSH prompt as well as sets us up to be able to include other dotfiles in the default user account via `/etc/skel`. If we eventually end up with conflicts with official `/etc/skel`, we may have to create a separate one then rig the installer to use that instead

Fixes #3, Fixes #1 